### PR TITLE
Fix: Restore CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @localheinz


### PR DESCRIPTION
This PR

* [x] restores `CODEOWNERS`

Reverts #6.