### PR TITLE
Fix: Remove @ergebnis-bot from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-*               @localheinz
-composer.json   @ergebnis-bot @localheinz
-composer.lock   @ergebnis-bot @localheinz
+* @localheinz


### PR DESCRIPTION
This PR

* [x] removes @ergebnis-bot from `CODEOWNERS`

Follows https://github.com/ergebnis/php-library-template/pull/363.