### PR TITLE
Fix: Add @ergebnis-bot to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
+* @ergebnis-bot
 * @localheinz


### PR DESCRIPTION
This PR

* [x] adds @ergebnis-bot to `CODEOWNERS`