### PR TITLE
Fix: CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @ergebnis-bot
-* @localheinz
+* @ergebnis-bot @localheinz


### PR DESCRIPTION
This PR

* [x] fixes `CODEOWNERS`