### PR TITLE
Fix: Update links to GitHub documentation

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,8 +3,8 @@
 branches:
   - name: "main"
 
-    # https://developer.github.com/v3/repos/branches/#remove-branch-protection
-    # https://developer.github.com/v3/repos/branches/#update-branch-protection
+    # https://docs.github.com/en/rest/reference/repos#delete-branch-protection
+    # https://docs.github.com/en/rest/reference/repos#update-branch-protection
 
     protection:
       enforce_admins: false
@@ -14,19 +14,18 @@ branches:
         required_approving_review_count: 1
       restrictions:
 
-        # https://developer.github.com/v3/repos/branches/#parameters-1
+        # https://docs.github.com/en/rest/reference/repos#list-branches--parameters
 
         # Note: User, app, and team restrictions are only available for organization-owned repositories.
         # Set to null to disable when using this configuration for a repository on a personal account.
 
-        apps:
-          - "dependabot-preview"
+        apps: []
         teams: []
         users:
           - "ergebnis-bot"
 
-# https://developer.github.com/v3/issues/labels/#create-a-label
-# https://developer.github.com/v3/issues/labels/#update-a-label
+# https://docs.github.com/en/rest/reference/issues#create-a-label
+# https://docs.github.com/en/rest/reference/issues#update-a-label
 
 labels:
   - name: "bug"
@@ -53,7 +52,7 @@ labels:
     color: "eeeeee"
     description: ""
 
-# https://developer.github.com/v3/repos/#edit
+# https://docs.github.com/en/rest/reference/repos#update-a-repository
 
 repository:
   allow_merge_commit: true
@@ -71,6 +70,6 @@ repository:
   name: ".github"
   private: false
 
-  # https://developer.github.com/v3/repos/branches/#remove-branch-protection
+  # https://docs.github.com/en/rest/reference/repos#replace-all-repository-topics
 
   topics: "default, community, health, files"

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Provides community health files for the [@ergebnis](https://github.com/ergebnis) organization.
 
-:bulb: Also see [GitHub Help: Creating a default community health file for your organization](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file-for-your-organization).
+:bulb: Also see [GitHub Docs: Creating a default community health file](https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file).


### PR DESCRIPTION
This PR

* [x] updates links to GitHub documentation

💁‍♂️ For reference, see https://twitter.com/github/status/1278433248994091022.