### PR TITLE
Fix: Code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ergebnis-bot @localheinz
+* @localheinz


### PR DESCRIPTION
This PR

* [x] attempts to fix `CODEOWNERS`
