### PR TITLE
Fix: Link to shop.localheinz.com instead of cottonbureau.com

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,6 +1,6 @@
 custom:
   - "https://buymeacoff.ee/localheinz"
-  - "https://cottonbureau.com/people/andreas-moller"
   - "https://ko-fi.com/localheinz"
+  - "https://shop.localheinz.com"
   - "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW"
 github: "localheinz"


### PR DESCRIPTION
This PR

* [x] links to `shop.localheinz.com` instead of `cottonbureau.com`