### PR TITLE
Fix: Run workflow on `pull_request_target`

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -3,7 +3,7 @@
 name: "Triage"
 
 on: # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - "opened"
 


### PR DESCRIPTION
This pull request

* [x] runs the triage workflow on `pull_request_target`