### PR TITLE
Fix: Use dashes instead of asterisks for unordered lists

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -6,8 +6,8 @@
 
 #### Expected Result
 
-* 
+- 
 
 #### Actual Result
 
-* 
+- 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 This pull request
 
-* [x] 
+- [x] 
 
 Follows #.
 Related to #.


### PR DESCRIPTION
This pull request

* [x] uses dashes instead of asterisks for unordered lists