### PR TITLE
Enhancement: Add `working-directory` input for `composer/install` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...main`][1.0.0...main].
+For a full diff see [`1.1.0...main`][1.1.0...main].
+
+## [`1.1.0`][1.1.0]
+
+For a full diff see [`1.0.0...1.1.0`][1.0.0...1.1.0].
+
+### Added
+
+- Added a `working-directory` input for the `composer/install` action ([#49]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -17,10 +25,13 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 - Added composite actions for determining the `composer` cache directory and installing dependencies with `composer` ([#47]), by [@localheinz]
 
 [1.0.0]: https://github.com/ergebnis/.github/releases/tag/1.0.0
+[1.1.0]: https://github.com/ergebnis/.github/releases/tag/1.1.0
 
 [ca7f15d...1.0.0]: https://github.com/ergebnis/php-package-template/compare/ca7f15d...1.0.0
-[1.0.0...main]: https://github.com/ergebnis/php-package-template/compare/1.0.0...main
+[1.0.0...1.1.0]: https://github.com/ergebnis/php-package-template/compare/1.0.0...1.1.0
+[1.1.0...main]: https://github.com/ergebnis/php-package-template/compare/1.1.0...main
 
 [#47]: https://github.com/ergebnis/.github/pull/47
+[#48]: https://github.com/ergebnis/.github/pull/48
 
 [@localheinz]: https://github.com/localheinz

--- a/actions/composer/install/action.yaml
+++ b/actions/composer/install/action.yaml
@@ -12,6 +12,10 @@ inputs:
     default: "locked"
     description: "Which dependencies to install, one of \"lowest\", \"locked\", \"highest\""
     required: true
+  working-directory:
+    default: "."
+    description: "Which directory to use as working directory"
+    required: true
 
 runs:
   using: "composite"
@@ -20,5 +24,6 @@ runs:
     - name: "Install ${{ inputs.dependencies }} dependencies with composer"
       env:
         COMPOSER_INSTALL_DEPENDENCIES: "${{ inputs.dependencies }}"
+        COMPOSER_INSTALL_WORKING_DIRECTORY: "${{ inputs.working-directory }}"
       run: "${{ github.action_path }}/run.sh"
       shell: "bash"

--- a/actions/composer/install/run.sh
+++ b/actions/composer/install/run.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
 
 dependencies="${COMPOSER_INSTALL_DEPENDENCIES}"
+workingDirectory="${COMPOSER_INSTALL_WORKING_DIRECTORY}"
+
+if [[ ! -d ${workingDirectory} ]]; then
+  echo "::error::The value for the \"working-directory\" input needs to be an existing directory. The directory \"${workingDirectory}\" does not exist."
+
+  exit 1;
+fi
 
 if [[ ${dependencies} == "lowest" ]]; then
-  composer update --ansi --no-interaction --no-progress --prefer-lowest
+  composer update --ansi --no-interaction --no-progress --prefer-lowest -working-dir="${workingDirectory}"
 
   exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
-  composer install --ansi --no-interaction --no-progress
+  composer install --ansi --no-interaction --no-progress -working-dir="${workingDirectory}"
 
   exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
-  composer update --ansi --no-interaction --no-progress
+  composer update --ansi --no-interaction --no-progress -working-dir="${workingDirectory}"
 
   exit $?
 fi


### PR DESCRIPTION
This pull request

- [x] adds a `working-directory` input for the `composer/install` action