### PR TITLE
Fix: Add missing dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.2.0...main`][1.2.0...main].
+For a full diff see [`1.2.1...main`][1.2.1...main].
+
+## [`1.2.1`][1.2.1]
+
+For a full diff see [`1.2.0...1.2.1`][1.2.0...1.2.1].
+
+### Fixed
+
+- Added missing dash when specifying `working-dir` option ([#54]), by [@localheinz]
 
 ## [`1.2.0`][1.2.0]
 
@@ -35,14 +43,17 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [1.0.0]: https://github.com/ergebnis/.github/releases/tag/1.0.0
 [1.1.0]: https://github.com/ergebnis/.github/releases/tag/1.1.0
 [1.2.0]: https://github.com/ergebnis/.github/releases/tag/1.2.0
+[1.2.1]: https://github.com/ergebnis/.github/releases/tag/1.2.1
 
 [ca7f15d...1.0.0]: https://github.com/ergebnis/.github/compare/ca7f15d...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/.github/compare/1.0.0...1.1.0
 [1.1.0...1.2.0]: https://github.com/ergebnis/.github/compare/1.1.0...1.2.0
-[1.2.0...main]: https://github.com/ergebnis/.github/compare/1.2.0...main
+[1.2.0...1.2.1]: https://github.com/ergebnis/.github/compare/1.2.0...1.2.1
+[1.2.1...main]: https://github.com/ergebnis/.github/compare/1.2.1...main
 
 [#47]: https://github.com/ergebnis/.github/pull/47
 [#48]: https://github.com/ergebnis/.github/pull/48
 [#52]: https://github.com/ergebnis/.github/pull/52
+[#54]: https://github.com/ergebnis/.github/pull/54
 
 [@localheinz]: https://github.com/localheinz

--- a/actions/composer/install/run.sh
+++ b/actions/composer/install/run.sh
@@ -10,19 +10,19 @@ if [[ ! -d ${workingDirectory} ]]; then
 fi
 
 if [[ ${dependencies} == "lowest" ]]; then
-    composer update --ansi --no-interaction --no-progress --prefer-lowest -working-dir="${workingDirectory}"
+    composer update --ansi --no-interaction --no-progress --prefer-lowest --working-dir="${workingDirectory}"
 
     exit $?
 fi
 
 if [[ ${dependencies} == "locked" ]]; then
-    composer install --ansi --no-interaction --no-progress -working-dir="${workingDirectory}"
+    composer install --ansi --no-interaction --no-progress --working-dir="${workingDirectory}"
 
     exit $?
 fi
 
 if [[ ${dependencies} == "highest" ]]; then
-    composer update --ansi --no-interaction --no-progress -working-dir="${workingDirectory}"
+    composer update --ansi --no-interaction --no-progress --working-dir="${workingDirectory}"
 
     exit $?
 fi


### PR DESCRIPTION
This pull request

- [x] adds an otherwise missing dash when specifying the `--working-dir` option 