### PR TITLE
Fix: Adjust usage of `octokit`

### DIFF
--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -41,7 +41,7 @@ jobs:
 
             const label = branchPrefixLabels[matches[1]];
 
-            github.issues.addLabels({
+            github.rest.issues.addLabels({
               issue_number: pullRequest.number,
               labels: [
                 label,


### PR DESCRIPTION
This pull request

- [x] adjusts the usage of `octokit` in the triage workflow