### PR TITLE
Fix: Use environment variable to pass input to script

### DIFF
--- a/actions/github/add-assignee-to-pull-request/action.yaml
+++ b/actions/github/add-assignee-to-pull-request/action.yaml
@@ -42,6 +42,8 @@ runs:
 
     - name: "Add assignee to pull request"
       uses: "actions/github-script@v5"
+      env:
+        ASSIGNEE: "${{ inputs.assignee }}"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
@@ -52,7 +54,7 @@ runs:
           }
 
           const assignees = [
-            core.getInput("assignee"),
+            process.env.ASSIGNEE,
           ];
 
           try {


### PR DESCRIPTION
This pull request

- [x] uses an environment variable to pass input to the script

💁‍♂️ For reference, see https://github.com/actions/github-script#use-env-as-input.