### PR TITLE
Fix: Require value for `working-directory` input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.4.1...main`][1.4.1...main].
 
+### Fixed
+
+- Required a value for the `working-directory` input of the composite action `composer/determine-cache-directory` ([#82]), by [@localheinz]
+
 ## [`1.4.1`][1.4.1]
 
 For a full diff see [`1.4.0...1.4.1`][1.4.0...1.4.1].

--- a/actions/composer/determine-cache-directory/action.yaml
+++ b/actions/composer/determine-cache-directory/action.yaml
@@ -11,7 +11,7 @@ inputs:
   working-directory:
     default: "."
     description: "Which directory to use as working directory"
-    required: false
+    required: true
 
 runs:
   using: "composite"


### PR DESCRIPTION
This pull request

- [x] requires a value for the `working-directory` input

💁‍♂️ It has a default value, so it should be fine to require it.