### PR TITLE
fix(actions) - expose correct variable name for branch name

### DIFF
--- a/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
+++ b/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
@@ -35,7 +35,7 @@ runs:
 
           if (context.eventName == 'workflow_run') {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
-            core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].head.ref);
+            core.exportVariable("PULL_REQUEST_BRANCH_NAME", context.payload.workflow_run.pull_requests[0].head.ref);
 
             return;
           }


### PR DESCRIPTION
This pull request

- [x] fixes envvar name exposed if workflow was triggered via `workflow_run` event (github/pull-request/add-label-based-on-branch-name)
