### PR TITLE
Fix Cache Key Calculation in Phive Install GitHub Action

### DIFF
--- a/actions/phive/install/action.yaml
+++ b/actions/phive/install/action.yaml
@@ -29,7 +29,7 @@ runs:
       uses: "actions/cache@v4.0.2"
       with:
         path: "${{ inputs.phive-home }}"
-        key: "phive-hashFiles('**/phars.xml')"
+        key: "phive-${{ hashFiles('**/phars.xml') }}"
         restore-keys: "phive-"
 
     - name: "Install dependencies with phive"


### PR DESCRIPTION
### Description

I've noticed a bug in the Phive install action where the cache key is incorrectly calculated. Instead of generating a hash from `phars.xml`, the function name is printed as a string, leading to cache failures when `phars.xml` is updated in a single pull request.

**Current Output:**

<img width="786" alt="Screenshot 2024-06-07 at 21 44 48" src="https://github.com/ergebnis/.github/assets/94047334/60b8c843-767d-4ed9-8d55-2d23c06690da">

**Fix:**
I updated the cache key calculation from:
```
key: "phive-hashFiles('**/phars.xml')"
```
to:
```
key: phive-${{ hashFiles('**/phars.xml') }}
```

**After fix is applied:**

<img width="801" alt="Screenshot 2024-06-07 at 22 51 40" src="https://github.com/ergebnis/.github/assets/94047334/f20eb97f-c870-4705-acc6-02e32eb0851a">


This should ensure the correct hash is generated and the cache is restored properly.

I encountered a similar issue in my [wayofdev/gh-actions](https://github.com/wayofdev/gh-actions) repository, which also uses Phive install inspired by your repository.

### How to check cache keys?:

https://github.com/cli/cli can be used to check all cache keys of repository:

```
gh cache list
```
