### PR TITLE
Enhancement: Add `github/actions/publish` to allow publishing a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.9.3...main`][1.9.3...main].
 
+### Added
+
+- Added `github/release/publish` to allow publishing a release ([#215]), by [@localheinz]
+
 ### Changed
 
 - Added a `draft` input to `github/release/create` to allow creating releases in draft mode ([#214]), by [@localheinz]
@@ -227,6 +231,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#208]: https://github.com/ergebnis/.github/pull/208
 [#209]: https://github.com/ergebnis/.github/pull/209
 [#214]: https://github.com/ergebnis/.github/pull/214
+[#215]: https://github.com/ergebnis/.github/pull/215
 
 [@dependabot]: https://github.com/dependabot
 [@jaymecd]: https://github.com/jaymecd

--- a/README.md
+++ b/README.md
@@ -525,6 +525,50 @@ none
 - The `RELEASE_ID` environment variable contains the release identifier.
 - The `RELEASE_TAG` environment variable contains the release tag.
 - The `RELEASE_UPLOAD_URL` environment variable contains the URL for uploading release assets.
+-
+### <a name="github-release-publish"> `ergebnis/.github/actions/github/release/publish`
+
+This action publishes a release.
+
+This is useful when you want to publish a release created in draft mode.
+
+```yaml
+
+name: "Release"
+
+on:
+  push:
+    tags:
+      - "**"
+
+jobs:
+  release:
+    name: "Release"
+
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Publish release"
+        uses: "ergebnis/.github/actions/github/release/publish@1.10.0"
+        with:
+          release-id: "9001"
+          github-token: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
+```
+
+For details, see [`actions/github/release/publish/action.yaml`](actions/github/release/publish/action.yaml).
+
+#### Inputs
+
+- `github-token`, required: The GitHub token of a user with permission to create a release.
+- `release-id`, required: The release identifier.
+
+#### Outputs
+
+none
+
+#### Side Effects
+
+- The release identified by the release identifier is published by the user who owns the GitHub token specified with the `github-token` input.
 
 ### <a name="oh-dear-check-request-run"> `ergebnis/.github/actions/oh-dear/check/request-run`
 

--- a/actions/github/release/publish/action.yaml
+++ b/actions/github/release/publish/action.yaml
@@ -1,0 +1,37 @@
+# https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs
+# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-composite-run-steps-actions
+# https://docs.github.com/en/rest/releases/releases#update-a-release
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push
+
+name: "Publish a release"
+
+description: "Publishes a release"
+
+inputs:
+  github-token:
+    description: "GitHub token of a user with permission to publish a release"
+    required: true
+  release-id:
+    description: "The release identifier"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: "Publish release"
+      uses: "actions/github-script@v7.0.1"
+      with:
+        github-token: "${{ inputs.github-token }}"
+        script: |
+          try {
+            const response = await github.rest.repos.updateRelease({
+              draft: false,
+              owner: context.repo.owner,
+              release_id: ${{ inputs.release-id }},
+              repo: context.repo.repo,
+            });
+          } catch (error) {
+            core.setFailed(error.message);
+          }


### PR DESCRIPTION
This pull request

- [x] adds `github/actions/publish` to allow publishing a release