### PR TITLE
Enhancement: Add `bug/` and `enhancement/` branch prefixes to label map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.11.0...main`][1.11.0...main].
 
+### Added
+
+- Added support for the `bug/` and `enhancement/` branch prefixes to `github/pull-request/add-label-based-on-branch-name` ([#251]), by [@localheinz]
+
 ## [`1.11.0`][1.11.0]
 
 For a full diff see [`1.10.0...1.11.0`][1.10.0...1.11.0].
@@ -253,6 +257,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#214]: https://github.com/ergebnis/.github/pull/214
 [#215]: https://github.com/ergebnis/.github/pull/215
 [#224]: https://github.com/ergebnis/.github/pull/224
+[#251]: https://github.com/ergebnis/.github/pull/251
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/README.md
+++ b/README.md
@@ -316,8 +316,8 @@ none
 
 #### Side Effects
 
-- When the branch name starts with `feature/`, the label `enhancement` is added to the pull request by the user who owns the GitHub token specified with the `github-token` input.
-- When the branch name starts with `fix/`, the label `bug` is added to the pull request by the user who owns the GitHub token specified with the `github-token` input.
+- When the branch name starts with `fix/` (or `bug/`), the label `bug` is added to the pull request by the user who owns the GitHub token specified with the `github-token` input.
+- When the branch name starts with `enhancement/` (or `feature/`), the label `enhancement` is added to the pull request by the user who owns the GitHub token specified with the `github-token` input.
 - The `PULL_REQUEST_BRANCH_NAME` environment variable contains the name of the head branch of the pull request.
 - The `PULL_REQUEST_NUMBER` environment variable contains the number of the pull request.
 

--- a/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
+++ b/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
@@ -60,6 +60,8 @@ runs:
           }
 
           const branchPrefixToLabel = {
+            bug: "bug",
+            enhancement: "enhancement",
             feature: "enhancement",
             fix: "bug",
           };


### PR DESCRIPTION
This pull request

- [x] adds the `bug/` and `enhancement/` branch prefixes to the label map
