### PR TITLE
Fix: Skip determining release tag when event is not a tag push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 ### Fixed
 
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to await adding the label ([#253]), by [@localheinz]
+- Adjusted `github/release/create` to skip determining the release tag when the event is not a tag push ([#255]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -269,6 +270,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#224]: https://github.com/ergebnis/.github/pull/224
 [#251]: https://github.com/ergebnis/.github/pull/251
 [#253]: https://github.com/ergebnis/.github/pull/253
+[#255]: https://github.com/ergebnis/.github/pull/255
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/github/release/create/action.yaml
+++ b/actions/github/release/create/action.yaml
@@ -26,7 +26,7 @@ runs:
 
   steps:
     - name: "Determine tag"
-      if: "${{ github.event_name }} == 'push' && ${{ github.ref_type }} == 'tag'"
+      if: "github.event_name == 'push' && github.ref_type == 'tag'"
       run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       shell: "bash"
 


### PR DESCRIPTION
This pull request

- [x] skips determining the release tag when the event is not a tag push
