### PR TITLE
Fix: Pass release identifier through environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to await adding the label ([#253]), by [@localheinz]
 - Adjusted `github/release/create` to skip determining the release tag when the event is not a tag push ([#255]), by [@localheinz]
+- Adjusted `github/release/publish` to pass the release identifier through the environment ([#256]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -272,6 +273,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#251]: https://github.com/ergebnis/.github/pull/251
 [#253]: https://github.com/ergebnis/.github/pull/253
 [#255]: https://github.com/ergebnis/.github/pull/255
+[#256]: https://github.com/ergebnis/.github/pull/256
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/github/release/publish/action.yaml
+++ b/actions/github/release/publish/action.yaml
@@ -22,14 +22,22 @@ runs:
   steps:
     - name: "Publish release"
       uses: "actions/github-script@v7.0.1"
+      env:
+        RELEASE_ID: "${{ inputs.release-id }}"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
+          if (!process.env.RELEASE_ID) {
+            core.setFailed("The environment variable RELEASE_ID is not defined.")
+
+            return;
+          }
+
           try {
             const response = await github.rest.repos.updateRelease({
               draft: false,
               owner: context.repo.owner,
-              release_id: ${{ inputs.release-id }},
+              release_id: process.env.RELEASE_ID,
               repo: context.repo.repo,
             });
 


### PR DESCRIPTION
This pull request

- [x] passes the release identifier through the environment
