### PR TITLE
Fix: Update `actions/github-script` for release publish action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -99,6 +99,19 @@ updates:
       prefix: "github-actions"
     cooldown:
       default-days: 7
+    directory: "/actions/github/release/publish"
+    labels:
+      - "dependency"
+    open-pull-requests-limit: 10
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+
+  - commit-message:
+      include: "scope"
+      prefix: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/actions/oh-dear/check/request-run"
     labels:
       - "dependency"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.12.0...main`][1.12.0...main].
 
+### Changed
+
+- Updated `actions/github-script` for `github/release/publish` and configured dependabot to keep it up to date ([#257]), by [@localheinz]
+
 ### Fixed
 
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to await adding the label ([#253]), by [@localheinz]
@@ -274,6 +278,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#253]: https://github.com/ergebnis/.github/pull/253
 [#255]: https://github.com/ergebnis/.github/pull/255
 [#256]: https://github.com/ergebnis/.github/pull/256
+[#257]: https://github.com/ergebnis/.github/pull/257
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/github/release/publish/action.yaml
+++ b/actions/github/release/publish/action.yaml
@@ -21,7 +21,7 @@ runs:
 
   steps:
     - name: "Publish release"
-      uses: "actions/github-script@v7.0.1"
+      uses: "actions/github-script@v9.0.0"
       env:
         RELEASE_ID: "${{ inputs.release-id }}"
       with:


### PR DESCRIPTION
This pull request

- [x] updates `actions/github-script` for the release publish action and configures dependabot to keep it up to date
