### PR TITLE
Fix: Fail when pull request cannot be determined for `workflow_run` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to await adding the label ([#253]), by [@localheinz]
 - Adjusted `github/release/create` to skip determining the release tag when the event is not a tag push ([#255]), by [@localheinz]
 - Adjusted `github/release/publish` to pass the release identifier through the environment ([#256]), by [@localheinz]
+- Adjusted `github/pull-request` actions to fail instead of throwing when the pull request cannot be determined for a `workflow_run` event ([#258]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -279,6 +280,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#255]: https://github.com/ergebnis/.github/pull/255
 [#256]: https://github.com/ergebnis/.github/pull/256
 [#257]: https://github.com/ergebnis/.github/pull/257
+[#258]: https://github.com/ergebnis/.github/pull/258
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/github/pull-request/add-assignee/action.yaml
+++ b/actions/github/pull-request/add-assignee/action.yaml
@@ -35,7 +35,11 @@ runs:
             return;
           }
 
-          if (context.eventName == 'workflow_run') {
+          if (
+            context.eventName == 'workflow_run' &&
+            Array.isArray(context.payload.workflow_run.pull_requests) &&
+            context.payload.workflow_run.pull_requests.length > 0
+          ) {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
 
             return;

--- a/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
+++ b/actions/github/pull-request/add-label-based-on-branch-name/action.yaml
@@ -33,7 +33,11 @@ runs:
             return;
           }
 
-          if (context.eventName == 'workflow_run') {
+          if (
+            context.eventName == 'workflow_run' &&
+            Array.isArray(context.payload.workflow_run.pull_requests) &&
+            context.payload.workflow_run.pull_requests.length > 0
+          ) {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
             core.exportVariable("PULL_REQUEST_BRANCH_NAME", context.payload.workflow_run.pull_requests[0].head.ref);
 

--- a/actions/github/pull-request/approve/action.yaml
+++ b/actions/github/pull-request/approve/action.yaml
@@ -32,7 +32,11 @@ runs:
             return;
           }
 
-          if (context.eventName == 'workflow_run') {
+          if (
+            context.eventName == 'workflow_run' &&
+            Array.isArray(context.payload.workflow_run.pull_requests) &&
+            context.payload.workflow_run.pull_requests.length > 0
+          ) {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
 
             return;

--- a/actions/github/pull-request/merge/action.yaml
+++ b/actions/github/pull-request/merge/action.yaml
@@ -36,7 +36,11 @@ runs:
             return;
           }
 
-          if (context.eventName == 'workflow_run') {
+          if (
+            context.eventName == 'workflow_run' &&
+            Array.isArray(context.payload.workflow_run.pull_requests) &&
+            context.payload.workflow_run.pull_requests.length > 0
+          ) {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
 
             return;

--- a/actions/github/pull-request/request-review/action.yaml
+++ b/actions/github/pull-request/request-review/action.yaml
@@ -35,7 +35,11 @@ runs:
             return;
           }
 
-          if (context.eventName == 'workflow_run') {
+          if (
+            context.eventName == 'workflow_run' &&
+            Array.isArray(context.payload.workflow_run.pull_requests) &&
+            context.payload.workflow_run.pull_requests.length > 0
+          ) {
             core.exportVariable("PULL_REQUEST_NUMBER", context.payload.workflow_run.pull_requests[0].number);
 
             return;


### PR DESCRIPTION
This pull request

- [x] fails when the pull request cannot be determined for a `workflow_run` event
