### PR TITLE
Fix: Fail when branch alias has not been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 - Adjusted `github/release/publish` to pass the release identifier through the environment ([#256]), by [@localheinz]
 - Adjusted `github/pull-request` actions to fail instead of throwing when the pull request cannot be determined for a `workflow_run` event ([#258]), by [@localheinz]
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to handle errors when adding labels ([#259]), by [@localheinz]
+- Adjusted `composer/determine-root-version` to fail when a branch alias has not been defined ([#261]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -283,6 +284,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#257]: https://github.com/ergebnis/.github/pull/257
 [#258]: https://github.com/ergebnis/.github/pull/258
 [#259]: https://github.com/ergebnis/.github/pull/259
+[#261]: https://github.com/ergebnis/.github/pull/261
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/composer/determine-root-version/run.sh
+++ b/actions/composer/determine-root-version/run.sh
@@ -20,9 +20,9 @@ fi
 COMPOSER_ROOT_VERSION=$(jq --arg key "dev-${branch}" --raw-output '.["extra"]["branch-alias"][$key]' "${pathToComposerJsonFile}")
 
 if [[ null = "${COMPOSER_ROOT_VERSION}" ]]; then
-    echo "::error:A branch alias has not been defined in \"${pathToComposerJsonFile}\" for branch \"${branch}\"."
+    echo "::error::A branch alias has not been defined in \"${pathToComposerJsonFile}\" for branch \"${branch}\"."
 
-    exit 0
+    exit 1
 fi
 
 echo "COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}" >> "${GITHUB_ENV}"


### PR DESCRIPTION
This pull request

- [x] fails when a branch alias has not been defined
