### PR TITLE
Fix: Fail when `composer` cache directory cannot be determined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 - Adjusted `github/pull-request` actions to fail instead of throwing when the pull request cannot be determined for a `workflow_run` event ([#258]), by [@localheinz]
 - Adjusted `github/pull-request/add-label-based-on-branch-name` to handle errors when adding labels ([#259]), by [@localheinz]
 - Adjusted `composer/determine-root-version` to fail when a branch alias has not been defined ([#261]), by [@localheinz]
+- Adjusted `composer/determine-cache-directory` to pass the working directory through the environment and to fail when the cache directory cannot be determined ([#262]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -285,6 +286,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#258]: https://github.com/ergebnis/.github/pull/258
 [#259]: https://github.com/ergebnis/.github/pull/259
 [#261]: https://github.com/ergebnis/.github/pull/261
+[#262]: https://github.com/ergebnis/.github/pull/262
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/composer/determine-cache-directory/action.yaml
+++ b/actions/composer/determine-cache-directory/action.yaml
@@ -18,5 +18,10 @@ runs:
 
   steps:
     - name: "Determine composer cache directory"
-      run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir --working-dir=${{ inputs.working-directory }})\" >> $GITHUB_ENV"
+      env:
+        COMPOSER_DETERMINE_CACHE_DIRECTORY_WORKING_DIRECTORY: "${{ inputs.working-directory }}"
+      run: |
+        COMPOSER_CACHE_DIR="$(composer config cache-dir --working-dir="${COMPOSER_DETERMINE_CACHE_DIRECTORY_WORKING_DIRECTORY}")"
+
+        echo "COMPOSER_CACHE_DIR=${COMPOSER_CACHE_DIR}" >> "${GITHUB_ENV}"
       shell: "bash"


### PR DESCRIPTION
This pull request

- [x] fails when the `composer` cache directory cannot be determined
