### PR TITLE
Fix: Fail `oh-dear` requests on HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a full diff see [`1.12.0...main`][1.12.0...main].
 - Adjusted `composer/determine-root-version` to fail when a branch alias has not been defined ([#261]), by [@localheinz]
 - Adjusted `composer/determine-cache-directory` to pass the working directory through the environment and to fail when the cache directory cannot be determined ([#262]), by [@localheinz]
 - Adjusted `phive/install` to pass inputs through the environment ([#263]), by [@localheinz]
+- Adjusted `oh-dear` actions to fail on HTTP errors and to pass inputs through the environment ([#264]), by [@localheinz]
 
 ## [`1.12.0`][1.12.0]
 
@@ -289,6 +290,7 @@ For a full diff see [`1.0.0...main`][1.0.0...main].
 [#261]: https://github.com/ergebnis/.github/pull/261
 [#262]: https://github.com/ergebnis/.github/pull/262
 [#263]: https://github.com/ergebnis/.github/pull/263
+[#264]: https://github.com/ergebnis/.github/pull/264
 
 [@dependabot]: https://github.com/dependabot
 [@ellisvalentiner]: https://github.com/ellisvalentiner

--- a/actions/oh-dear/check/request-run/action.yaml
+++ b/actions/oh-dear/check/request-run/action.yaml
@@ -20,9 +20,14 @@ runs:
 
   steps:
     - name: "Request a check run on ohdear.app"
+      env:
+        OH_DEAR_API_TOKEN: "${{ inputs.oh-dear-api-token }}"
+        OH_DEAR_CHECK_ID: "${{ inputs.oh-dear-check-id }}"
       run: |
-        curl -X POST "https://ohdear.app/api/checks/${{ inputs.oh-dear-check-id }}/request-run" \
-          -H "Authorization: Bearer ${{ inputs.oh-dear-api-token }}" \
-          -H "Accept: application/json" \
-          -H "Content-Type: application/json"
+        curl --url "https://ohdear.app/api/checks/${OH_DEAR_CHECK_ID}/request-run" \
+          --fail \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer ${OH_DEAR_API_TOKEN}" \
+          --header "Content-Type: application/json" \
+          --request POST
       shell: "bash"

--- a/actions/oh-dear/maintenance-period/start/action.yaml
+++ b/actions/oh-dear/maintenance-period/start/action.yaml
@@ -20,9 +20,14 @@ runs:
 
   steps:
     - name: "Start maintenance period on ohdear.app"
+      env:
+        OH_DEAR_API_TOKEN: "${{ inputs.oh-dear-api-token }}"
+        OH_DEAR_SITE_ID: "${{ inputs.oh-dear-site-id }}"
       run: |
-        curl -X POST https://ohdear.app/api/sites/${{ inputs.oh-dear-site-id }}/start-maintenance \
-          -H "Authorization: Bearer ${{ inputs.oh-dear-api-token }}" \
-          -H "Accept: application/json" \
-          -H "Content-Type: application/json"
+        curl --url "https://ohdear.app/api/sites/${OH_DEAR_SITE_ID}/start-maintenance" \
+          --fail \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer ${OH_DEAR_API_TOKEN}" \
+          --header "Content-Type: application/json" \
+          --request POST
       shell: "bash"

--- a/actions/oh-dear/maintenance-period/stop/action.yaml
+++ b/actions/oh-dear/maintenance-period/stop/action.yaml
@@ -20,9 +20,14 @@ runs:
 
   steps:
     - name: "Stop maintenance period on ohdear.app"
+      env:
+        OH_DEAR_API_TOKEN: "${{ inputs.oh-dear-api-token }}"
+        OH_DEAR_SITE_ID: "${{ inputs.oh-dear-site-id }}"
       run: |
-        curl -X POST https://ohdear.app/api/sites/${{ inputs.oh-dear-site-id }}/stop-maintenance \
-          -H "Authorization: Bearer ${{ inputs.oh-dear-api-token }}" \
-          -H "Accept: application/json" \
-          -H "Content-Type: application/json"
+        curl --url "https://ohdear.app/api/sites/${OH_DEAR_SITE_ID}/stop-maintenance" \
+          --fail \
+          --header "Accept: application/json" \
+          --header "Authorization: Bearer ${OH_DEAR_API_TOKEN}" \
+          --header "Content-Type: application/json" \
+          --request POST
       shell: "bash"


### PR DESCRIPTION
This pull request

- [x] fails `oh-dear` requests on HTTP errors
