### PR TITLE
Fix: Correct `merge-method` input metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ For details, see [`actions/github/pull-request/merge/action.yaml`](actions/githu
 #### Inputs
 
 - `github-token`, required: The GitHub token of a user with permission to merge a pull request
-- `merge-method`, option: The merge method to use, one `"merge"`, `"rebase"`, `"squash"`, defaults to `"merge"`
+- `merge-method`, optional: The merge method to use, one of `"merge"`, `"rebase"`, `"squash"`, defaults to `"merge"`
 
 #### Outputs
 

--- a/actions/github/pull-request/merge/action.yaml
+++ b/actions/github/pull-request/merge/action.yaml
@@ -15,8 +15,8 @@ inputs:
     required: true
   merge-method:
     default: "merge"
-    description: "Which merge method to use, one \"merge\", \"rebase\", \"squash\""
-    required: true
+    description: "Which merge method to use, one of \"merge\", \"rebase\", \"squash\""
+    required: false
 
 runs:
   using: "composite"


### PR DESCRIPTION
This pull request

- [x] corrects `merge-method` input metadata
