### PR TITLE
Enhancement: Configure `dependabot` to group `github-actions` updates by dependency name

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,6 +24,10 @@ updates:
       - "/actions/oh-dear/maintenance-period/start"
       - "/actions/oh-dear/maintenance-period/stop"
       - "/actions/phive/install"
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        group-by: "dependency-name"
     labels:
       - "dependency"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request

- [x] configures `dependabot` to group `github-actions` updates by dependency name
